### PR TITLE
Check for Nil response (PHNX-3021)

### DIFF
--- a/notifier.go
+++ b/notifier.go
@@ -46,19 +46,19 @@ func notifyStateChange(info *monitorInfo, newStatus bool) error {
 	for i := 0; i < retryAttempts; i++ {
 		client := &http.Client{}
 		resp, err := client.Do(req)
-		if resp == nil {
-			return err
-		}
-		defer resp.Body.Close()
+		if resp != nil {
 
-		log.WithFields(log.Fields{
-			"svc": info.ServiceName,
-			"pod": info.PodName,
-			"ns":  info.Namespace,
-		}).Debug("Notification result ", resp.Status)
+			defer resp.Body.Close()
 
-		if err == nil {
-			return nil
+			log.WithFields(log.Fields{
+				"svc": info.ServiceName,
+				"pod": info.PodName,
+				"ns":  info.Namespace,
+			}).Debug("Notification result ", resp.Status)
+
+			if err == nil {
+				return nil
+			}
 		}
 
 		time.Sleep(retryInterval)

--- a/notifier.go
+++ b/notifier.go
@@ -1,68 +1,68 @@
 package main
 
 import (
-  "bytes"
-  "encoding/json"
-  "net/http"
-  "time"
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"time"
 
-  log "github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
-  activeStatus = "active"
-  inactiveStatus = "inactive"
+	activeStatus   = "active"
+	inactiveStatus = "inactive"
 
-  retryAttempts = 3
+	retryAttempts = 3
 )
 
 type stateChangeDto struct {
-  Status string `json:"status"`
+	Status string `json:"status"`
 }
 
 var retryInterval, _ = time.ParseDuration("1s")
 
 func notifyStateChange(info *monitorInfo, newStatus bool) error {
-  var err error
+	var err error
 
-  state := stateChangeDto{}
+	state := stateChangeDto{}
 
-  if newStatus {
-    state.Status = activeStatus
-  } else {
-    state.Status = inactiveStatus
-  }
+	if newStatus {
+		state.Status = activeStatus
+	} else {
+		state.Status = inactiveStatus
+	}
 
-  body, err := json.Marshal(&state)
-  if err != nil {
-    return err
-  }
+	body, err := json.Marshal(&state)
+	if err != nil {
+		return err
+	}
 
-  req, err := http.NewRequest(http.MethodPost, info.URL, bytes.NewBuffer(body))
-  if err != nil {
-    return err
-  }
+	req, err := http.NewRequest(http.MethodPost, info.URL, bytes.NewBuffer(body))
+	if err != nil {
+		return err
+	}
 
-  for i := 0; i < retryAttempts; i++ {
-    client := &http.Client{}
-    resp, err := client.Do(req)
-    if resp == nil {
-      return err
-    }
-    defer resp.Body.Close()
+	for i := 0; i < retryAttempts; i++ {
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if resp == nil {
+			return err
+		}
+		defer resp.Body.Close()
 
-    log.WithFields(log.Fields{
-      "svc": info.ServiceName,
-      "pod": info.PodName,
-      "ns": info.Namespace,
-    }).Debug("Notification result ", resp.Status)
+		log.WithFields(log.Fields{
+			"svc": info.ServiceName,
+			"pod": info.PodName,
+			"ns":  info.Namespace,
+		}).Debug("Notification result ", resp.Status)
 
-    if err == nil {
-      return nil
-    }
+		if err == nil {
+			return nil
+		}
 
-    time.Sleep(retryInterval)
-  }
+		time.Sleep(retryInterval)
+	}
 
-  return err
+	return err
 }

--- a/notifier.go
+++ b/notifier.go
@@ -1,65 +1,68 @@
 package main
 
 import (
-	"bytes"
-	"encoding/json"
-	"net/http"
-	"time"
+  "bytes"
+  "encoding/json"
+  "net/http"
+  "time"
 
-	log "github.com/sirupsen/logrus"
+  log "github.com/sirupsen/logrus"
 )
 
 const (
-	activeStatus   = "active"
-	inactiveStatus = "inactive"
+  activeStatus = "active"
+  inactiveStatus = "inactive"
 
-	retryAttempts = 3
+  retryAttempts = 3
 )
 
 type stateChangeDto struct {
-	Status string `json:"status"`
+  Status string `json:"status"`
 }
 
 var retryInterval, _ = time.ParseDuration("1s")
 
 func notifyStateChange(info *monitorInfo, newStatus bool) error {
-	var err error
+  var err error
 
-	state := stateChangeDto{}
+  state := stateChangeDto{}
 
-	if newStatus {
-		state.Status = activeStatus
-	} else {
-		state.Status = inactiveStatus
-	}
+  if newStatus {
+    state.Status = activeStatus
+  } else {
+    state.Status = inactiveStatus
+  }
 
-	body, err := json.Marshal(&state)
-	if err != nil {
-		return err
-	}
+  body, err := json.Marshal(&state)
+  if err != nil {
+    return err
+  }
 
-	req, err := http.NewRequest(http.MethodPost, info.URL, bytes.NewBuffer(body))
-	if err != nil {
-		return err
-	}
+  req, err := http.NewRequest(http.MethodPost, info.URL, bytes.NewBuffer(body))
+  if err != nil {
+    return err
+  }
 
-	for i := 0; i < retryAttempts; i++ {
-		client := &http.Client{}
-		resp, err := client.Do(req)
-		defer resp.Body.Close()
+  for i := 0; i < retryAttempts; i++ {
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    if resp == nil {
+      return err
+    }
+    defer resp.Body.Close()
 
-		log.WithFields(log.Fields{
-			"svc": info.ServiceName,
-			"pod": info.PodName,
-			"ns":  info.Namespace,
-		}).Debug("Notification result ", resp.Status)
+    log.WithFields(log.Fields{
+      "svc": info.ServiceName,
+      "pod": info.PodName,
+      "ns": info.Namespace,
+    }).Debug("Notification result ", resp.Status)
 
-		if err == nil {
-			return nil
-		}
+    if err == nil {
+      return nil
+    }
 
-		time.Sleep(retryInterval)
-	}
+    time.Sleep(retryInterval)
+  }
 
-	return err
+  return err
 }


### PR DESCRIPTION
Motivation
---
Without checking for a nil value for the response from a client.Do call, we run the risk of attempting to reference a property of a null object which would cause our program to hard crash.

This is based off my own learning of Go and the following reference:
https://medium.com/@KeithAlpichi/go-gotcha-closing-a-nil-http-response-body-with-defer-9b7a3eb30e8c

I may be off base; in which case, we can ignore this PR.

Modification
---
- Check the response from our client call and return err if the resp is null

https://centeredge.atlassian.net/browse/PHNX-3021
