### PR TITLE
Use service acct name in examples (ARCH-59)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.go,go.mod]
+[*.{go,mod}]
 indent_style = tab
 end_of_line = lf
 

--- a/example/injected/k8s-sidecar-injector.yaml
+++ b/example/injected/k8s-sidecar-injector.yaml
@@ -2,11 +2,30 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: shawarma
+  name: shawarma-webhook
 rules:
 - apiGroups: [""]
-  resources: ["endpoints"]
+  resources: ["serviceaccounts"]
   verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: shawarma
+subjects:
+- kind: ServiceAccount
+  name: shawarma-webhook
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: shawarma-webhook
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: shawarma-webhook
+  namespace: kube-system
 ---
 apiVersion: v1
 kind: Service
@@ -57,6 +76,7 @@ spec:
       labels:
         k8s-app: shawarma-webhook
     spec:
+      serviceAccountName: shawarma-webhook
       volumes:
       - name: secrets
         secret:
@@ -64,7 +84,10 @@ spec:
       containers:
       - name: shawarma-webhook
         imagePullPolicy: Always
-        image: centeredge/shawarma-webhook:0.1.0
+        image: centeredge/shawarma-webhook:0.2.0
+        env:
+        - name: LOG_LEVEL
+          value: warn
         ports:
         - name: https
           containerPort: 443
@@ -101,6 +124,12 @@ webhooks:
     apiGroups: [""]
     apiVersions: ["v1"]
     resources: ["pods"]
+  namespaceSelector:
+    # Require that the namespace have the `shawarma-injection: enabled` label
+    matchExpressions:
+    - key: shawarma-injection
+      operator: In
+      values: ["enabled"]
   clientConfig:
     service:
       name: shawarma-webhook

--- a/example/injected/rbac.yaml
+++ b/example/injected/rbac.yaml
@@ -1,15 +1,32 @@
 # This file should be applied to each namespace where Shawarma sidecars are in use
 # It creates a service account and token to be attached to the Shawarma sidecar
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: shawarma-example
+  labels:
+    shawarma-injection: enabled
+---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: Role
 metadata:
   name: shawarma
+  namespace: shawarma-example
+rules:
+- apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: shawarma
+  namespace: shawarma-example
 subjects:
 - kind: ServiceAccount
   name: shawarma
-  namespace: default
 roleRef:
-  kind: ClusterRole
+  kind: Role
   name: shawarma
   apiGroup: rbac.authorization.k8s.io
 ---
@@ -17,17 +34,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: shawarma
-  namespace: default
-secrets:
-- name: shawarma-token
----
-# We must manually create a token for the service account so that it has a known name
-# This name must be "shawarma-token" or be overridden in the webhook deployment using the SHAWARMA_SECRET_TOKEN_NAME env var
-apiVersion: v1
-kind: Secret
-metadata:
-  name: shawarma-token
-  namespace: default
-  annotations:
-    kubernetes.io/service-account.name: shawarma
-type: kubernetes.io/service-account-token
+  namespace: shawarma-example

--- a/example/injected/test-pod.yaml
+++ b/example/injected/test-pod.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: shawarma-example
+  namespace: shawarma-example
   labels:
     svc: shawarma-example
 spec:
@@ -17,6 +18,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: shawarma-example
+  namespace: shawarma-example
   labels:
     app: shawarma-example
 spec:


### PR DESCRIPTION
Motivation
----------
Update the injected deployment example to use the new service account
name method, which is simpler.

Modifications
-------------
Updated to use shawarma-webhook 0.2.0, and use the service account name
method.

Also moved the example into the "shawarma-example" namespace, and used
the namespace label filter to prevent webhook calls for other
spaces.

https://centeredge.atlassian.net/browse/ARCH-59
