### PR TITLE
Fix Spelling Mistake Regarding Detailed Help (SWS-4147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ so normally it is run using the Docker container `centeredge/shawarma`.
 
 For detailed help:
 
-`docker run --rm -it centeredge/swarma monitor --help`
+`docker run --rm -it centeredge/shawarma monitor --help`
 
 ## Arguments
 


### PR DESCRIPTION
Motivation
---
 - I was trying to run the command in the readme to get detailed help
 - I received errors regarding the image name

Modification
---
 - Updated the image name in the readme to match the real one

https://centeredge.atlassian.net/browse/SWS-4147
