### PR TITLE
Allow the container to terminate gracefully

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,7 @@ github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=

--- a/main.go
+++ b/main.go
@@ -31,12 +31,15 @@ func main() {
 			Value:  "warn",
 			EnvVar: "LOG_LEVEL",
 		},
+		cli.StringFlag{
+			Name:  "kubeconfig",
+			Usage: "Path to a kubeconfig file, if not running in-cluster",
+		},
 	}
 	app.Before = func(c *cli.Context) error {
 		// In case of empty environment variable, pull default here too
 		levelString := c.String("log-level")
 		if levelString == "" {
-			levelString = "warn"
 		}
 
 		level, err := log.ParseLevel(levelString)
@@ -80,10 +83,11 @@ func main() {
 			},
 			Action: func(c *cli.Context) error {
 				info := monitorInfo{
-					Namespace:   c.String("namespace"),
-					PodName:     c.String("pod"),
-					ServiceName: c.String("service"),
-					URL:         c.String("url"),
+					Namespace:    c.String("namespace"),
+					PodName:      c.String("pod"),
+					ServiceName:  c.String("service"),
+					URL:          c.String("url"),
+					PathToConfig: c.GlobalString("kubeconfig"),
 				}
 
 				// In case of empty environment variable, pull default here too


### PR DESCRIPTION
Motivation
----------
Currently SIGINT and SIGTERM are not handled correctly.

Modifications
-------------
Instead of triggering the stop channel, close the stop channel. This
correctly signals the K8S controller to stop.

Add some additional debug logging.

Add a command line switch to use a local kubeconfig file instead of only
running in-cluster. This makes local dev easier.