### PR TITLE
Added application/json as content type on post request

### DIFF
--- a/notifier.go
+++ b/notifier.go
@@ -39,6 +39,7 @@ func notifyStateChange(info *monitorInfo, newStatus bool) error {
 	}
 
 	req, err := http.NewRequest(http.MethodPost, info.URL, bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Before this change headers does not contain the conent type for the body.
```
 "headers": {
        "host": "localhost",
        "user-agent": "Go-http-client/1.1",
        "content-length": "19",
        "accept-encoding": "gzip"
    },
    "method": "POST",
    "body": "{\"status\":\"active\"}",
```

Suggested solution is to include the content type as        "content-type": "application/json; charset=UTF-8",



 ```
"headers": {

        "host": "localhost",
        "user-agent": "Go-http-client/1.1",
        "content-length": "19",
        **"content-type": "application/json; charset=UTF-8",**
        "accept-encoding": "gzip"
    },

    "method": "POST",
    "body": "{\"status\":\"active\"}",
```


This will prevent server application to respond with 415 Unsupported Media Type
