### PR TITLE
feat: support http status endpoint 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ the load balancer, and uses an HTTP POST to let your application know the state.
 application must simply receive the POST and start or stop background processing.
 
 ## HTTP Endpoint
-An optional feature also provides a simple http server to store the current pod status,
+An optional feature on this sidecar also provides a simple http server to store the current pod status,
 this enable other use cases where the main container can ask to the sidecar without
-the requirement to create a new endpoint on the main service. Simply GET to the endpoint
-`/deploymentstatus` will return the pod service status:
+the need to create a new endpoint on the main service or understand k8s API. 
+A simply GET call to the endpoint `/deploymentstatus` will return the pod service status as json:
+
 ```
 curl -X GET http://localhost:8099/deploymentstatus -i
 HTTP/1.1 200 OK
@@ -41,11 +42,10 @@ Content-Length: 19
 {"status":"active"}                                        
 ```
 
-Where `localhost` will be the shawarma container interface (binding just to local one)
+Where `localhost` will be the shawarma sidecar container interface (binding just to local one)
 
 This configuration needs just an extra env config to set the http server port to listen:
   - LISTEN_PORT (int, default: 8099)
-
 ## Example
 
 To see an example deployment utilizing Shawarma, see (./example/basic/example.yaml).
@@ -93,5 +93,5 @@ If specified both places, the command line takes precendence.
 | --pod           | MY_POD_NAME             | Kubernetes pod name, typically a fieldRef to `fieldPath: metadata.name` |
 | --service       | SHAWARMA_SERVICE        | Name of the Kubernetes service to monitor |
 | --url           | SHAWARMA_URL            | URL which receives a POST on state change, default: <http://localhost/applicationstate> |
-| --state-notifier| SHAWARMA_STATE_NOTIFIER | Enable/Disable POST Notification behavior (true,false) (default: "true") |
+| --state-notifier| SHAWARMA_STATE_NOTIFIER | Enable/Disable POST Notification behavior (bool) (default: "true") |
 | --listen-port   | LISTEN_PORT             | PORT to be used to start the HTTP Server |

--- a/README.md
+++ b/README.md
@@ -27,25 +27,28 @@ the load balancer, and uses an HTTP POST to let your application know the state.
 application must simply receive the POST and start or stop background processing.
 
 ## HTTP Endpoint
+
 An optional feature on this sidecar also provides a simple http server to store the current pod status,
 this enable other use cases where the main container can ask to the sidecar without
-the need to create a new endpoint on the main service or understand k8s API. 
+the need to create a new endpoint on the main service or understand k8s API.
 A simply GET call to the endpoint `/deploymentstate` will return the pod service status as json:
 
-```
+```text
 curl -X GET http://localhost:8099/deploymentstate -i
 HTTP/1.1 200 OK
 Content-Type: application/json
 Date: Tue, 12 Apr 2022 12:32:22 GMT
 Content-Length: 19
 
-{"status":"active"}                                        
+{"status":"active"}
 ```
 
 Where `localhost` will be the shawarma sidecar container interface (binding just to local one)
 
 This configuration needs just an extra env config to set the http server port to listen:
-  - LISTEN_PORT (int, default: 8099)
+
+- LISTEN_PORT (int, default: 8099)
+
 ## Example
 
 To see an example deployment utilizing Shawarma, see (./example/basic/example.yaml).

--- a/README.md
+++ b/README.md
@@ -26,6 +26,26 @@ application. It monitors the Kubernetes API to know when the pod is or is not co
 the load balancer, and uses an HTTP POST to let your application know the state. Your
 application must simply receive the POST and start or stop background processing.
 
+## HTTP Endpoint
+An optional feature also provides a simple http server to store the current pod status,
+this enable other use cases where the main container can ask to the sidecar without
+the requirement to create a new endpoint on the main service. Simply GET to the endpoint
+`/deploymentstatus` will return the pod service status:
+```
+curl -X GET http://localhost:8099/deploymentstatus -i
+HTTP/1.1 200 OK
+Content-Type: application/json
+Date: Tue, 12 Apr 2022 12:32:22 GMT
+Content-Length: 19
+
+{"status":"active"}                                        
+```
+
+Where `localhost` will be the shawarma container interface (binding just to local one)
+
+This configuration needs just an extra env config to set the http server port to listen:
+  - LISTEN_PORT (int, default: 8099)
+
 ## Example
 
 To see an example deployment utilizing Shawarma, see (./example/basic/example.yaml).
@@ -66,10 +86,12 @@ For detailed help:
 Most arguments can be specified either on the command line, or via an environment variable.
 If specified both places, the command line takes precendence.
 
-| Name        | Env Var          | Description |
-| ----------- | ---------------- | ----------- |
-| --log-level | LOG_LEVEL        | Set the log level (panic, fatal, error, warn, info, debug, trace) (default: "warn") |
-| --namespace | MY_POD_NAMESPACE | Kubernetes namespace, typically a fieldRef to `fieldPath: metadata.namespace` |
-| --pod       | MY_POD_NAME      | Kubernetes pod name, typically a fieldRef to `fieldPath: metadata.name` |
-| --service   | SHAWARMA_SERVICE | Name of the Kubernetes service to monitor |
-| --url       | SHAWARMA_URL     | URL which receives a POST on state change, default: <http://localhost/applicationstate> |
+| Name            | Env Var                 | Description |
+| --------------- | ----------------------- | ----------- |
+| --log-level     | LOG_LEVEL               | Set the log level (panic, fatal, error, warn, info, debug, trace) (default: "warn") |
+| --namespace     | MY_POD_NAMESPACE        | Kubernetes namespace, typically a fieldRef to `fieldPath: metadata.namespace` |
+| --pod           | MY_POD_NAME             | Kubernetes pod name, typically a fieldRef to `fieldPath: metadata.name` |
+| --service       | SHAWARMA_SERVICE        | Name of the Kubernetes service to monitor |
+| --url           | SHAWARMA_URL            | URL which receives a POST on state change, default: <http://localhost/applicationstate> |
+| --state-notifier| SHAWARMA_STATE_NOTIFIER | Enable/Disable POST Notification behavior (true,false) (default: "true") |
+| --listen-port   | LISTEN_PORT             | PORT to be used to start the HTTP Server |

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Where `localhost` will be the shawarma sidecar container interface (binding just
 
 This configuration needs just an extra env config to set the http server port to listen:
 
-- LISTEN_PORT (int, default: 8099)
+- SHAWARMA_LISTEN_PORT (int, default: 8099)
 
 ## Example
 
@@ -97,4 +97,4 @@ If specified both places, the command line takes precendence.
 | --service       | SHAWARMA_SERVICE        | Name of the Kubernetes service to monitor |
 | --url           | SHAWARMA_URL            | URL which receives a POST on state change, default: <http://localhost/applicationstate> |
 | --disable-notifier| SHAWARMA_DISABLE_STATE_NOTIFIER | Enable/Disable POST Notification behavior (bool) (default: "true") |
-| --listen-port   | LISTEN_PORT             | PORT to be used to start the HTTP Server |
+| --listen-port   | SHAWARMA_LISTEN_PORT    | PORT to be used to start the HTTP Server |

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ application must simply receive the POST and start or stop background processing
 An optional feature on this sidecar also provides a simple http server to store the current pod status,
 this enable other use cases where the main container can ask to the sidecar without
 the need to create a new endpoint on the main service or understand k8s API. 
-A simply GET call to the endpoint `/deploymentstatus` will return the pod service status as json:
+A simply GET call to the endpoint `/deploymentstate` will return the pod service status as json:
 
 ```
-curl -X GET http://localhost:8099/deploymentstatus -i
+curl -X GET http://localhost:8099/deploymentstate -i
 HTTP/1.1 200 OK
 Content-Type: application/json
 Date: Tue, 12 Apr 2022 12:32:22 GMT

--- a/README.md
+++ b/README.md
@@ -93,5 +93,5 @@ If specified both places, the command line takes precendence.
 | --pod           | MY_POD_NAME             | Kubernetes pod name, typically a fieldRef to `fieldPath: metadata.name` |
 | --service       | SHAWARMA_SERVICE        | Name of the Kubernetes service to monitor |
 | --url           | SHAWARMA_URL            | URL which receives a POST on state change, default: <http://localhost/applicationstate> |
-| --state-notifier| SHAWARMA_STATE_NOTIFIER | Enable/Disable POST Notification behavior (bool) (default: "true") |
+| --disable-notifier| SHAWARMA_DISABLE_STATE_NOTIFIER | Enable/Disable POST Notification behavior (bool) (default: "true") |
 | --listen-port   | LISTEN_PORT             | PORT to be used to start the HTTP Server |

--- a/example/basic/example.yaml
+++ b/example/basic/example.yaml
@@ -16,7 +16,7 @@ subjects:
   name: shawarma-example
   namespace: default
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: shawarma
   apiGroup: rbac.authorization.k8s.io
 ---

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/sirupsen/logrus v1.4.2
+	github.com/stretchr/testify v1.4.0
 	github.com/urfave/cli v1.20.0
 	k8s.io/api v0.19.12
 	k8s.io/apimachinery v0.19.12

--- a/main.go
+++ b/main.go
@@ -81,11 +81,10 @@ func main() {
 					Usage:  "URL which receives a POST on state change",
 					EnvVar: "SHAWARMA_URL",
 				},
-				cli.StringFlag{
-					Name:   "state-notifier, s",
-					Value:  "true",
+				cli.BoolFlag{
+					Name:   "disable-notifier, d",
 					Usage:  "Enable/Disable state change notification",
-					EnvVar: "SHAWARMA_STATE_NOTIFIER",
+					EnvVar: "SHAWARMA_DISABLE_STATE_NOTIFIER",
 				},
 				cli.StringFlag{
 					Name:   "listen-port, l",
@@ -96,12 +95,12 @@ func main() {
 			},
 			Action: func(c *cli.Context) error {
 				info := monitorInfo{
-					Namespace:     c.String("namespace"),
-					PodName:       c.String("pod"),
-					ServiceName:   c.String("service"),
-					URL:           c.String("url"),
-					StateNotifier: c.Bool("state-notifier"),
-					PathToConfig:  c.GlobalString("kubeconfig"),
+					Namespace:            c.String("namespace"),
+					PodName:              c.String("pod"),
+					ServiceName:          c.String("service"),
+					URL:                  c.String("url"),
+					DisableStateNotifier: c.Bool("disable-notifier"),
+					PathToConfig:         c.GlobalString("kubeconfig"),
 				}
 
 				// In case of empty environment variable, pull default here too

--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ func main() {
 					Name:   "listen-port, l",
 					Value:  8099,
 					Usage:  "Default port to be used to start the http server",
-					EnvVar: "LISTEN_PORT",
+					EnvVar: "SHAWARMA_LISTEN_PORT",
 				},
 			},
 			Action: func(c *cli.Context) error {

--- a/main.go
+++ b/main.go
@@ -81,20 +81,36 @@ func main() {
 					Usage:  "URL which receives a POST on state change",
 					EnvVar: "SHAWARMA_URL",
 				},
+				cli.StringFlag{
+					Name:   "state-notifier, s",
+					Value:  "true",
+					Usage:  "Enable/Disable state change notification",
+					EnvVar: "SHAWARMA_STATE_NOTIFIER",
+				},
+				cli.StringFlag{
+					Name:   "listen-port, l",
+					Value:  "8099",
+					Usage:  "Default port to be used to start the http server",
+					EnvVar: "LISTEN_PORT",
+				},
 			},
 			Action: func(c *cli.Context) error {
 				info := monitorInfo{
-					Namespace:    c.String("namespace"),
-					PodName:      c.String("pod"),
-					ServiceName:  c.String("service"),
-					URL:          c.String("url"),
-					PathToConfig: c.GlobalString("kubeconfig"),
+					Namespace:     c.String("namespace"),
+					PodName:       c.String("pod"),
+					ServiceName:   c.String("service"),
+					URL:           c.String("url"),
+					StateNotifier: c.Bool("state-notifier"),
+					PathToConfig:  c.GlobalString("kubeconfig"),
 				}
 
 				// In case of empty environment variable, pull default here too
 				if info.URL == "" {
 					info.URL = "http://localhost/applicationstate"
 				}
+
+				// Start server in a Go routine thread
+				go httpServer(c.String("listen-port"))
 
 				return monitorService(&info)
 			},
@@ -105,4 +121,5 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
 }

--- a/main.go
+++ b/main.go
@@ -86,9 +86,9 @@ func main() {
 					Usage:  "Enable/Disable state change notification",
 					EnvVar: "SHAWARMA_DISABLE_STATE_NOTIFIER",
 				},
-				cli.StringFlag{
+				cli.IntFlag{
 					Name:   "listen-port, l",
-					Value:  "8099",
+					Value:  8099,
 					Usage:  "Default port to be used to start the http server",
 					EnvVar: "LISTEN_PORT",
 				},

--- a/monitor.go
+++ b/monitor.go
@@ -68,7 +68,7 @@ func processStateChange(info *monitorInfo, newState bool) {
 
 	go func() {
 		// Set new State
-		setStateChange(newState)
+		setStateChange(newState, info)
 		// Notify if is enabled
 		if info.StateNotifier {
 			logContext.Debug("Posting state change notification...")

--- a/monitor.go
+++ b/monitor.go
@@ -19,12 +19,12 @@ import (
 var isActive = false
 
 type monitorInfo struct {
-	Namespace     string
-	PodName       string
-	ServiceName   string
-	URL           string
-	PathToConfig  string
-	StateNotifier bool
+	Namespace            string
+	PodName              string
+	ServiceName          string
+	URL                  string
+	PathToConfig         string
+	DisableStateNotifier bool
 }
 
 func processEndpoint(info *monitorInfo, endpoint *v1.Endpoints) {
@@ -70,7 +70,7 @@ func processStateChange(info *monitorInfo, newState bool) {
 		// Set new State
 		setStateChange(newState, info)
 		// Notify if is enabled
-		if info.StateNotifier {
+		if !info.DisableStateNotifier {
 			logContext.Debug("Posting state change notification...")
 			err := notifyStateChange(info)
 			if err != nil {

--- a/notifier.go
+++ b/notifier.go
@@ -22,16 +22,19 @@ type stateChangeDto struct {
 
 var retryInterval, _ = time.ParseDuration("1s")
 
-func notifyStateChange(info *monitorInfo, newStatus bool) error {
-	var err error
+var state = stateChangeDto{Status: inactiveStatus}
 
-	state := stateChangeDto{}
-
+func setStateChange(newStatus bool) {
 	if newStatus {
 		state.Status = activeStatus
 	} else {
 		state.Status = inactiveStatus
 	}
+	log.Debug("State status set to: ", state.Status)
+}
+
+func notifyStateChange(info *monitorInfo) error {
+	var err error
 
 	body, err := json.Marshal(&state)
 	if err != nil {

--- a/notifier.go
+++ b/notifier.go
@@ -24,13 +24,19 @@ var retryInterval, _ = time.ParseDuration("1s")
 
 var state = stateChangeDto{Status: inactiveStatus}
 
-func setStateChange(newStatus bool) {
+func setStateChange(newStatus bool, info *monitorInfo) {
 	if newStatus {
 		state.Status = activeStatus
 	} else {
 		state.Status = inactiveStatus
 	}
-	log.Debug("State status set to: ", state.Status)
+
+	log.WithFields(log.Fields{
+		"svc": info.ServiceName,
+		"pod": info.PodName,
+		"ns":  info.Namespace,
+	}).Debug("State status set to: ", state.Status)
+
 }
 
 func notifyStateChange(info *monitorInfo) error {

--- a/server.go
+++ b/server.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Handlers
-func deploymentStatus(w http.ResponseWriter, req *http.Request) {
+func deploymentState(w http.ResponseWriter, req *http.Request) {
 	st, err := json.Marshal(&state)
 	if err != nil {
 		panic("Json encoding issue: " + err.Error())
@@ -32,7 +32,7 @@ func _health(w http.ResponseWriter, req *http.Request) {
 func httpServer(port string) {
 
 	// Endpoints Handlers
-	http.HandleFunc("/deploymentstatus", deploymentStatus)
+	http.HandleFunc("/deploymentstate", deploymentState)
 	http.HandleFunc("/_health", _health)
 
 	log.Info(fmt.Sprintf("Starting HTTP Server on port %s", port))

--- a/server.go
+++ b/server.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// get OS environment variable, fallback as default
+func getenv(key, fallback string) string {
+	value := os.Getenv(key)
+	if len(value) == 0 {
+		return fallback
+	}
+	return value
+}
+
+// Handlers
+func deploymentStatus(w http.ResponseWriter, req *http.Request) {
+	st, err := json.Marshal(&state)
+	if err != nil {
+		panic("Json encoding issue: " + err.Error())
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	fmt.Fprintf(w, string(st))
+}
+
+func _health(w http.ResponseWriter, req *http.Request) {
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	fmt.Fprintf(w, `{"health": "ok"}`)
+}
+
+// Http Server
+func httpServer(default_port string) {
+
+	// Endpoints Handlers
+	http.HandleFunc("/deploymentstatus", deploymentStatus)
+	http.HandleFunc("/_health", _health)
+
+	// Get OS envs
+	port := getenv("LISTEN_PORT", default_port)
+	log.Info(fmt.Sprintf("Starting HTTP Server on port %s", port))
+
+	// Listener
+	err := http.ListenAndServe(fmt.Sprintf("%s:%s", "localhost", port), nil)
+	if err != nil {
+		panic("Error: " + err.Error())
+	}
+
+}

--- a/server.go
+++ b/server.go
@@ -4,19 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 
 	log "github.com/sirupsen/logrus"
 )
-
-// get OS environment variable, fallback as default
-func getenv(key, fallback string) string {
-	value := os.Getenv(key)
-	if len(value) == 0 {
-		return fallback
-	}
-	return value
-}
 
 // Handlers
 func deploymentStatus(w http.ResponseWriter, req *http.Request) {
@@ -39,14 +29,12 @@ func _health(w http.ResponseWriter, req *http.Request) {
 }
 
 // Http Server
-func httpServer(default_port string) {
+func httpServer(port string) {
 
 	// Endpoints Handlers
 	http.HandleFunc("/deploymentstatus", deploymentStatus)
 	http.HandleFunc("/_health", _health)
 
-	// Get OS envs
-	port := getenv("LISTEN_PORT", default_port)
 	log.Info(fmt.Sprintf("Starting HTTP Server on port %s", port))
 
 	// Listener

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type Endpoint struct {
+	method   string
+	url      string
+	expected string
+}
+
+var serverEndpoints = []Endpoint{
+	Endpoint{"GET", "/_health", `{"health": "ok"}`},
+	Endpoint{"GET", "/deploymentstatus", `{"status":"inactive"}`},
+}
+
+func TestEndpoints(t *testing.T) {
+	assert := assert.New(t)
+
+	for _, endpoint := range serverEndpoints {
+
+		req := httptest.NewRequest(endpoint.method, endpoint.url, nil)
+		w := httptest.NewRecorder()
+		router(endpoint, w, req)
+
+		// Parse output
+		result := w.Result()
+		defer result.Body.Close()
+		data, err := ioutil.ReadAll(result.Body)
+
+		// Err validation
+		if err != nil {
+			t.Errorf("expected error to be nil got %v", err)
+		}
+
+		// Asserts
+		assert.Equal(200, result.StatusCode, fmt.Sprintf("expected 200 - got %v", result.StatusCode))
+		assert.Equal(endpoint.expected, string(data), fmt.Sprintf("expected %s - got %v", endpoint.expected, string(data)))
+	}
+}
+
+func router(endpoint Endpoint, w *httptest.ResponseRecorder, req *http.Request) {
+	// Route handler
+	if endpoint.url == "/_health" {
+		_health(w, req)
+	}
+	if endpoint.url == "/deploymentstatus" {
+		deploymentStatus(w, req)
+	}
+
+}

--- a/server_test.go
+++ b/server_test.go
@@ -18,7 +18,7 @@ type Endpoint struct {
 
 var serverEndpoints = []Endpoint{
 	Endpoint{"GET", "/_health", `{"health": "ok"}`},
-	Endpoint{"GET", "/deploymentstatus", `{"status":"inactive"}`},
+	Endpoint{"GET", "/deploymentstate", `{"status":"inactive"}`},
 }
 
 func TestEndpoints(t *testing.T) {
@@ -51,8 +51,8 @@ func router(endpoint Endpoint, w *httptest.ResponseRecorder, req *http.Request) 
 	if endpoint.url == "/_health" {
 		_health(w, req)
 	}
-	if endpoint.url == "/deploymentstatus" {
-		deploymentStatus(w, req)
+	if endpoint.url == "/deploymentstate" {
+		deploymentState(w, req)
 	}
 
 }


### PR DESCRIPTION
Motivation
----------
In some use cases async notifications are not the best option (workers without exposed endpoints, implementations that need to add extra complexity to have a dedicated listener to start/stop consumers). In those cases support a simple HTTP endpoint to expose the current pod status on the sidecar (avoid main service needs to understand k8s API) is a good option and requires small changes

Modifications
-------------
+ added HTTP server listening on `SHAWARMA_LISTEN_PORT` to retrieve pod status on `deploymentstate/` endpoint
+ added health endpoint on `_health`
+ Added testing to HTTP server endpoints
+ Optional opt-out to notification service if is not required with `SHAWARMA_DISABLE_STATE_NOTIFIER` variable
+ set default status on startup to `inactive`

