### PR TITLE
Add ARM64 Docker image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -32,19 +32,20 @@ jobs:
             type=semver,pattern={{major}}
             type=sha
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,15 @@
 FROM golang:1.18 as build
 
-# Install upx to compress executable after compilation
-RUN apt-get update && \
-    apt-get install -y xz-utils && \
-    mkdir -p /opt/upx && \
-    cd /opt/upx && \
-    wget -q https://github.com/upx/upx/releases/download/v3.96/upx-3.96-amd64_linux.tar.xz -O ./upx.tar.xz && \
-    tar --strip-components 1 -xf upx.tar.xz && \
-    rm -rf /var/lib/apt/lists/* upx.tar.xz
-
 # Install modules first for caching
 WORKDIR /app
 ENV GO111MODULE=on
 COPY go.* ./
 RUN go mod download
 
-# Build the application, and compress with upx
+# Build the application
 ARG VERSION
 COPY ./ ./
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X main.version=${VERSION:-0.0.0}" && \
-    /opt/upx/upx shawarma
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X main.version=${VERSION:-0.0.0}"
 
 # Copy compiled output to a fresh image
 FROM scratch


### PR DESCRIPTION
Motivation
------------
ARM is increasing in popularity in the cloud and on Mac.

Modifications
---------------
Drop UPX for compression, load speed is really more valuable than image
size.

Upgrade GH actions versions for Docker and add the AMD64 platform.