### PR TITLE
Monitor services by label instead of name 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ application. It monitors the Kubernetes API to know when the pod is or is not co
 the load balancer, and uses an HTTP POST to let your application know the state. Your
 application must simply receive the POST and start or stop background processing.
 
+The Kubernetes Service may be referenced either by name (using `--service`) or by one or
+more labels (using `--service-labels`). If both are supplied then all must match. If more
+than one Service is matched the the application is considered active if any Service includes
+the pod.
+
 ## HTTP Endpoint
 
 An optional feature on this sidecar also provides a simple http server to store the current pod status,
@@ -89,12 +94,13 @@ For detailed help:
 Most arguments can be specified either on the command line, or via an environment variable.
 If specified both places, the command line takes precendence.
 
-| Name            | Env Var                 | Description |
-| --------------- | ----------------------- | ----------- |
-| --log-level     | LOG_LEVEL               | Set the log level (panic, fatal, error, warn, info, debug, trace) (default: "warn") |
-| --namespace     | MY_POD_NAMESPACE        | Kubernetes namespace, typically a fieldRef to `fieldPath: metadata.namespace` |
-| --pod           | MY_POD_NAME             | Kubernetes pod name, typically a fieldRef to `fieldPath: metadata.name` |
-| --service       | SHAWARMA_SERVICE        | Name of the Kubernetes service to monitor |
-| --url           | SHAWARMA_URL            | URL which receives a POST on state change, default: <http://localhost/applicationstate> |
-| --disable-notifier| SHAWARMA_DISABLE_STATE_NOTIFIER | Enable/Disable POST Notification behavior (bool) (default: "true") |
-| --listen-port   | SHAWARMA_LISTEN_PORT    | PORT to be used to start the HTTP Server |
+| Name               | Env Var                 | Description |
+| ------------------ | ----------------------- | ----------- |
+| --log-level        | LOG_LEVEL               | Set the log level (panic, fatal, error, warn, info, debug, trace) (default: "warn") |
+| --namespace        | MY_POD_NAMESPACE        | Kubernetes namespace, typically a fieldRef to `fieldPath: metadata.namespace` |
+| --pod              | MY_POD_NAME             | Kubernetes pod name, typically a fieldRef to `fieldPath: metadata.name` |
+| --service          | SHAWARMA_SERVICE        | Name of the Kubernetes service to monitor |
+| --service-labels   | SHAWARMA_SERVICE_LABELS | Kubernetes service labels to monitor, comma-delimited ex. `label1=value1,label2=value2` |
+| --url              | SHAWARMA_URL            | URL which receives a POST on state change, default: <http://localhost/applicationstate> |
+| --disable-notifier | SHAWARMA_DISABLE_STATE_NOTIFIER | Enable/Disable POST Notification behavior (bool) (default: "true") |
+| --listen-port      | SHAWARMA_LISTEN_PORT    | PORT to be used to start the HTTP Server |

--- a/example/basic/example.yaml
+++ b/example/basic/example.yaml
@@ -56,7 +56,7 @@ spec:
         app: shawarma-example
         active: 'true'
       annotations:
-        shawarma.centeredge.io/service-name: shawarma-example
+        shawarma.centeredge.io/service-labels: svc=shawarma-example
     spec:
       serviceAccountName: shawarma-example
       containers:
@@ -66,6 +66,13 @@ spec:
           ports:
           - name: http
             containerPort: 80
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
         - name: shawarma
           # Using latest is not recommended for production, specify a version number
           image: centeredge/shawarma:latest
@@ -77,6 +84,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.annotations['shawarma.centeredge.io/service-name']
+            - name: SHAWARMA_SERVICE_LABELS
+              # References service to monitor
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['shawarma.centeredge.io/service-labels']
             - name: SHAWARMA_URL
               # Will POST state to this URL as pod is attached/detached from the service
               value: http://localhost/applicationstate
@@ -90,8 +102,8 @@ spec:
                   fieldPath: metadata.namespace
           resources:
             requests:
-              cpu: "0.1"
-              memory: 128Mi
+              cpu: 10m
+              memory: 64Mi
             limits:
-              cpu: "0.2"
-              memory: 128Mi
+              cpu: 10m
+              memory: 64Mi

--- a/main.go
+++ b/main.go
@@ -67,6 +67,11 @@ func main() {
 					EnvVars: []string{"SHAWARMA_SERVICE"},
 				},
 				&cli.StringFlag{
+					Name:    "service-labels",
+					Usage:   "Kubernetes service labels to monitor for this pod, comma-delimited ex. \"label1=value1,label2=value2\"",
+					EnvVars: []string{"SHAWARMA_SERVICE_LABELS"},
+				},
+				&cli.StringFlag{
 					Name:    "pod",
 					Aliases: []string{"p"},
 					Usage:   "Kubernetes pod to monitor",
@@ -105,9 +110,14 @@ func main() {
 					Namespace:            c.String("namespace"),
 					PodName:              c.String("pod"),
 					ServiceName:          c.String("service"),
+					ServiceLabelSelector: c.String("service-labels"),
 					URL:                  c.String("url"),
 					DisableStateNotifier: c.Bool("disable-notifier"),
 					PathToConfig:         c.String("kubeconfig"),
+				}
+
+				if info.ServiceName == "" && info.ServiceLabelSelector == "" {
+					return cli.Exit("The service name or labels must be supplied", 1)
 				}
 
 				// In case of empty environment variable, pull default here too

--- a/monitor.go
+++ b/monitor.go
@@ -8,7 +8,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/fields"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
@@ -22,43 +23,84 @@ type monitorInfo struct {
 	Namespace            string
 	PodName              string
 	ServiceName          string
+	ServiceLabelSelector string
 	URL                  string
 	PathToConfig         string
 	DisableStateNotifier bool
 }
 
-func processEndpoint(info *monitorInfo, endpoint *v1.Endpoints) {
+// Tracks the current state
+type monitorState struct {
+	info *monitorInfo
+
+	// List of endpoints known to be active, when empty this means we should deactivate the application
+	endpoints []types.UID
+}
+
+func (info *monitorInfo) EnrichLogFields(fields log.Fields) log.Fields {
+	fields["pod"] = info.PodName
+	fields["ns"] = info.Namespace
+
+	if len(info.ServiceName) > 0 {
+		fields["svc"] = info.ServiceName
+	}
+
+	if len(info.ServiceLabelSelector) > 0 {
+		fields["lbl"] = info.ServiceLabelSelector
+	}
+
+	return fields
+}
+
+func (info *monitorInfo) ToLogFields() log.Fields {
+	return info.EnrichLogFields(log.Fields{})
+}
+
+func processEndpoint(state *monitorState, endpoint *v1.Endpoints, isAddOrUpdate bool) {
 	foundPod := false
 
-	for _, subset := range endpoint.Subsets {
-		for _, address := range subset.Addresses {
-			if address.TargetRef != nil &&
-				address.TargetRef.Kind == "Pod" &&
-				address.TargetRef.Namespace == info.Namespace &&
-				address.TargetRef.Name == info.PodName {
-				foundPod = true
+	if isAddOrUpdate {
+		for _, subset := range endpoint.Subsets {
+			for _, address := range subset.Addresses {
+				if address.TargetRef != nil &&
+					address.TargetRef.Kind == "Pod" &&
+					address.TargetRef.Namespace == state.info.Namespace &&
+					address.TargetRef.Name == state.info.PodName {
+					foundPod = true
+					break
+				}
+			}
+
+			if foundPod {
 				break
 			}
 		}
+	}
 
-		if foundPod {
+	endpointIndex := -1
+	for i := range state.endpoints {
+		if state.endpoints[i] == endpoint.UID {
+			endpointIndex = i
 			break
 		}
 	}
 
-	if (foundPod && !isActive) || (!foundPod && isActive) {
-		processStateChange(info, foundPod)
+	if foundPod && endpointIndex == -1 {
+		state.endpoints = append(state.endpoints, endpoint.UID)
+	} else if !foundPod && endpointIndex >= 0 {
+		state.endpoints = append(state.endpoints[:endpointIndex], state.endpoints[endpointIndex+1:]...)
+	}
+
+	shouldBeActive := len(state.endpoints) > 0
+	if shouldBeActive != isActive {
+		processStateChange(state.info, shouldBeActive)
 	}
 }
 
 func processStateChange(info *monitorInfo, newState bool) {
 	isActive = newState
 
-	logContext := log.WithFields(log.Fields{
-		"svc": info.ServiceName,
-		"pod": info.PodName,
-		"ns":  info.Namespace,
-	})
+	logContext := log.WithFields(info.ToLogFields())
 
 	if newState {
 		logContext.Info("Activated")
@@ -99,14 +141,24 @@ func monitorService(info *monitorInfo) error {
 		return err
 	}
 
+	// Maintain the state here for use in the callback below
+	state := monitorState{
+		info:      info,
+		endpoints: []types.UID{},
+	}
+
 	for stopRequested := false; !stopRequested; {
-		watchList := cache.NewListWatchFromClient(
+		watchList := cache.NewFilteredListWatchFromClient(
 			clientset.CoreV1().RESTClient(),
 			"endpoints",
 			info.Namespace,
-			fields.SelectorFromSet(fields.Set{
-				"metadata.name": info.ServiceName,
-			}),
+			func(options *metav1.ListOptions) {
+				if len(info.ServiceName) > 0 {
+					options.FieldSelector = "metadata.name=" + info.ServiceName
+				}
+
+				options.LabelSelector = info.ServiceLabelSelector
+			},
 		)
 
 		_, controller := cache.NewInformer(
@@ -118,22 +170,19 @@ func monitorService(info *monitorInfo) error {
 					endpoint := obj.(*v1.Endpoints)
 
 					log.Debugf("endpoint %s added", endpoint.Name)
-					processEndpoint(info, endpoint)
+					processEndpoint(&state, endpoint, true)
 				},
 				DeleteFunc: func(obj interface{}) {
 					endpoint := obj.(*v1.Endpoints)
 
 					log.Debugf("endpoint %s deleted", endpoint.Name)
-
-					if isActive {
-						processStateChange(info, false)
-					}
+					processEndpoint(&state, endpoint, false)
 				},
 				UpdateFunc: func(oldObj, newObj interface{}) {
 					endpoint := newObj.(*v1.Endpoints)
 
 					log.Debugf("endpoint %s changed", endpoint.Name)
-					processEndpoint(info, endpoint)
+					processEndpoint(&state, endpoint, true)
 				},
 			},
 		)

--- a/notifier.go
+++ b/notifier.go
@@ -31,13 +31,9 @@ func setStateChange(newStatus bool, info *monitorInfo) {
 		state.Status = inactiveStatus
 	}
 
-	log.WithFields(log.Fields{
-		"svc":    info.ServiceName,
-		"pod":    info.PodName,
-		"ns":     info.Namespace,
+	log.WithFields(info.EnrichLogFields(log.Fields{
 		"status": state.Status,
-	}).Debug("State changed.")
-
+	})).Debug("State changed.")
 }
 
 func notifyStateChange(info *monitorInfo) error {
@@ -61,11 +57,7 @@ func notifyStateChange(info *monitorInfo) error {
 
 			defer resp.Body.Close()
 
-			log.WithFields(log.Fields{
-				"svc": info.ServiceName,
-				"pod": info.PodName,
-				"ns":  info.Namespace,
-			}).Debug("Notification result ", resp.Status)
+			log.WithFields(info.ToLogFields()).Debug("Notification result ", resp.Status)
 
 			if err == nil {
 				return nil


### PR DESCRIPTION
Motivation
------------
In some infrastructures it is easier and more flexible to identify a
service by labels rather than by name. This is especially true if the
name is getting a suffix via Kustomize.

Modifications
---------------
Optionally allow a list of labels used to identify the service(s) to
monitor rather than a name.

Results
-------
This change is fully backward compatible, any configuration which
supplies a name will work as-is.

If labels are supplied, more than one service may be monitored. In
this case the application is considered active if at least one service
includes an endpoint for the pod.