### PR TITLE
Add active services to DTO

### DIFF
--- a/monitor.go
+++ b/monitor.go
@@ -167,8 +167,7 @@ func (monitor *Monitor) Start() error {
 	// Subscribe to state changes
 	monitor.stateChange = make(chan monitorState)
 	go func() {
-		for {
-			state := <-monitor.stateChange
+		for state := range monitor.stateChange {
 			monitor.processStateChange(state)
 		}
 	}()


### PR DESCRIPTION
Motivation
------------
When monitoring multiple services via labels, there may be cases where
the list of active services is valuable to the application.

Modifications
---------------
Add the list of active services to the DTO. Change the state tracking
for endpoints to uses names instead of UID so we have the names
to send.

Rewrite the monitor into a class and use channels to queue the state
changes. This ensures that state changes are delivered in order and
without thread sync issues when multiple changes happen quickly.

Move stop logic based on SIGTERM/SIGINT out of the monitor and
into the command line system, which makes more sense.