### PR TITLE
Add debounce to state changes

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,11 +11,24 @@ on:
       - 'main'
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3 
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - run: go mod download
+      - run: go vet
+      - run: go test
+
   docker:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4

--- a/debounce.go
+++ b/debounce.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"time"
+)
+
+// Debounces events received on a channel, returning the last event received
+// after the delay is past.
+func debounce[T interface{}](delay time.Duration, events chan T) chan T {
+	return debounceWithBuffer(delay, events, 0)
+}
+
+// Debounces events received on a channel, returning the last event received
+// after the delay is past.
+func debounceWithBuffer[T interface{}](delay time.Duration, events chan T, outputBufferSize int) chan T {
+	output := make(chan T, outputBufferSize)
+
+	go func() {
+		for event := range events {
+		L:
+			for {
+				select {
+				case tempEvent, ok := <-events:
+					if !ok {
+						// But if events is closed go ahead and output the last event and break out of the inner loop
+						// which will then fall out of the outer loop and close the output
+						output <- event
+						break L
+					} else {
+						// Replaces the `event` local with the new event that was received while waiting
+						event = tempEvent
+					}
+
+				case <-time.After(delay):
+					// Forward the final event present after the delay and break out of the inner loop
+					// which will wait for the next event to arrive
+					output <- event
+					break L
+				}
+			}
+		}
+
+		// Close the output once the input is closed
+		close(output)
+	}()
+
+	return output
+}

--- a/debounce_test.go
+++ b/debounce_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDebounce_InputClosed_OutputClosed(t *testing.T) {
+	assert := assert.New(t)
+
+	input := make(chan struct{})
+
+	output := debounce(50*time.Millisecond, input)
+
+	close(input)
+
+	_, ok := <-output
+
+	assert.False(ok)
+}
+
+func TestDebounce_SingleEvent_Received(t *testing.T) {
+	assert := assert.New(t)
+
+	input := make(chan int)
+
+	output := debounce(50*time.Millisecond, input)
+
+	input <- 1
+	received := <-output
+
+	assert.Equal(1, received)
+
+	close(input)
+}
+
+func TestDebounce_MultipleEvents_ReceiveLast(t *testing.T) {
+	assert := assert.New(t)
+
+	input := make(chan int)
+
+	output := debounce(50*time.Millisecond, input)
+
+	input <- 1
+	input <- 2
+	input <- 3
+	received := <-output
+
+	assert.Equal(3, received)
+
+	close(input)
+}
+
+func TestDebounce_CloseAfterMultipleEvents_ReceiveLast(t *testing.T) {
+	assert := assert.New(t)
+
+	input := make(chan int)
+
+	output := debounce(50*time.Millisecond, input)
+
+	input <- 1
+	input <- 2
+	input <- 3
+	close(input)
+	received := <-output
+
+	assert.Equal(3, received)
+}
+
+func TestDebounce_EventsAfterDelay_ReceivesBeforeAndAfter(t *testing.T) {
+	assert := assert.New(t)
+
+	input := make(chan int)
+
+	output := debounce(10*time.Millisecond, input)
+
+	start := time.Now()
+	input <- 1
+	input <- 2
+	input <- 3
+	received := <-output
+
+	assert.Equal(3, received)
+	assert.LessOrEqual(10*time.Millisecond, time.Since(start))
+
+	start = time.Now()
+	input <- 4
+	input <- 5
+	received = <-output
+
+	assert.Equal(5, received)
+	assert.LessOrEqual(10*time.Millisecond, time.Since(start))
+
+	close(input)
+}

--- a/monitor.go
+++ b/monitor.go
@@ -167,7 +167,7 @@ func (monitor *Monitor) Start() error {
 	// Subscribe to state changes
 	monitor.stateChange = make(chan monitorState)
 	go func() {
-		for state := range monitor.stateChange {
+		for state := range debounce(100*time.Millisecond, monitor.stateChange) {
 			monitor.processStateChange(state)
 		}
 	}()

--- a/server_test.go
+++ b/server_test.go
@@ -17,8 +17,8 @@ type Endpoint struct {
 }
 
 var serverEndpoints = []Endpoint{
-	Endpoint{"GET", "/_health", `{"health": "ok"}`},
-	Endpoint{"GET", "/deploymentstate", `{"status":"inactive"}`},
+	{"GET", "/_health", `{"health": "ok"}`},
+	{"GET", "/deploymentstate", `{"status":"inactive","activeServices":[]}`},
 }
 
 func TestEndpoints(t *testing.T) {


### PR DESCRIPTION
Motivation
------------
When monitoring multiple services by label state changes may
flood the application.

Modifications
---------------
Debounce any change events by 100ms to allow multiple state
changes to be posted as a single change.

Fix server_test and add unit tests to CI runs.