### PR TITLE
Support running as a non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,12 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w -X main.version=${VERSION:-0.0.0}"
 
 # Copy compiled output to a fresh image
-FROM scratch
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /app
+
 COPY --from=build /app/shawarma /app/shawarma
+
+USER 65532:65532
 ENTRYPOINT [ "/app/shawarma" ]
 CMD ["monitor"]

--- a/example/basic/example.yaml
+++ b/example/basic/example.yaml
@@ -76,6 +76,11 @@ spec:
         - name: shawarma
           # Using latest is not recommended for production, specify a version number
           image: centeredge/shawarma:latest
+          securityContext:
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            runAsNonRoot: true
           env:
             - name: LOG_LEVEL
               value: DEBUG


### PR DESCRIPTION
Motivation
------------
More secure K8S clusters may require that pods run with
certain security restrictions, such as non-root users.

Modifications
---------------
Change the base image to use a non-root user.

Update the example to apply a securityContext to the
Shawarma container that meets the Restricted policy for K8S.