### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,4 +1,6 @@
 name: ci
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/CenterEdge/shawarma/security/code-scanning/2](https://github.com/CenterEdge/shawarma/security/code-scanning/2)

To fix this issue, add a `permissions` block to the workflow file specifying the least privileges required. Place the `permissions` block at the root level (preferred), so all jobs inherit it unless they need more privilege. Based on the workflow, both jobs only require read access to the code (`contents: read`). If any job requires greater access, the permissions block can be placed in that job specifically. For this workflow, add the following block after the `name:` and before `on:`:
```yaml
permissions:
  contents: read
```

No new imports, definitions, or dependencies are needed.  
Explicitly limiting permissions in this way prevents escalation and adheres to best security practice.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
