### PR TITLE
Use EndpointSlices instead of Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,19 @@ Shawarma requires access rights, via a service account, to monitor endpoints wit
 pod's namespace. It is recommended to create a single Role named `shawarma'
 in the namespace, and then bind it to each service account using a RoleBinding.
 
+For the current version of Shawarma, only `endpointslices` is required. However, the example
+below includes `endpoints` for backward compatibility with older versions of Shawarma
+running mixed in the same cluster.
+
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: shawarma
 rules:
+- apiGroups: ["discovery.k8s.io"]
+  resources: ["endpointslices"]
+  verbs: ["get", "watch", "list"]
 - apiGroups: [""]
   resources: ["endpoints"]
   verbs: ["get", "watch", "list"]

--- a/endpointslicecache.go
+++ b/endpointslicecache.go
@@ -1,0 +1,136 @@
+// Based upon https://github.com/kubernetes/kubernetes/blob/58f2d96901b9bc0e90f5c6fb5bc808a7aa86a851/pkg/proxy/endpointslicecache.go
+
+package main
+
+import (
+	"fmt"
+	"iter"
+	"reflect"
+	"sync"
+
+	discovery "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+)
+
+type EndpointSliceCache struct {
+	// lock protects trackerByServiceMap.
+	lock sync.Mutex
+
+	// trackerByServiceMap is the basis of this cache. It contains endpoint
+	// slice trackers grouped by service name and endpoint slice name. The first
+	// key represents a namespaced service name while the second key represents
+	// an endpoint slice name. Since endpoints can move between slices, we
+	// require slice specific caching to prevent endpoints being removed from
+	// the cache when they may have just moved to a different slice.
+	trackerByServiceMap map[types.NamespacedName]*endpointSliceTracker
+}
+
+// endpointSliceTracker keeps track of EndpointSlices as they have been applied
+// by a proxier along with any pending EndpointSlices that have been updated
+// in this cache but not yet applied by a proxier.
+type endpointSliceTracker struct {
+	slices endpointSliceDataByName // All known EndpointSlices for a service.
+}
+
+// endpointSliceDataByName groups endpointSliceData by the names of the
+// corresponding EndpointSlices.
+type endpointSliceDataByName map[string]*discovery.EndpointSlice
+
+// NewEndpointSliceCache initializes an EndpointSliceCache.
+func NewEndpointSliceCache() *EndpointSliceCache {
+	return &EndpointSliceCache{
+		trackerByServiceMap: map[types.NamespacedName]*endpointSliceTracker{},
+	}
+}
+
+// newEndpointSliceTracker initializes an endpointSliceTracker.
+func newEndpointSliceTracker() *endpointSliceTracker {
+	return &endpointSliceTracker{
+		slices: endpointSliceDataByName{},
+	}
+}
+
+// Update updates a slice in the cache.
+func (cache *EndpointSliceCache) Update(endpointSlice *discovery.EndpointSlice, remove bool) bool {
+	serviceKey, sliceKey, err := endpointSliceCacheKeys(endpointSlice)
+	if err != nil {
+		klog.ErrorS(err, "Error getting endpoint slice cache keys")
+		return false
+	}
+
+	cache.lock.Lock()
+	defer cache.lock.Unlock()
+
+	byServiceData, ok := cache.trackerByServiceMap[serviceKey]
+	if !ok {
+		byServiceData = newEndpointSliceTracker()
+		cache.trackerByServiceMap[serviceKey] = byServiceData
+	}
+
+	if remove {
+		if _, ok := byServiceData.slices[sliceKey]; ok {
+			delete(byServiceData.slices, sliceKey)
+			return true
+		}
+	} else {
+		if cache.isEndpointSliceChanged(serviceKey, sliceKey, endpointSlice) {
+			byServiceData.slices[sliceKey] = endpointSlice
+			return true
+		}
+	}
+
+	return false
+}
+
+func (cache *EndpointSliceCache) Services() iter.Seq2[types.NamespacedName, iter.Seq[*discovery.Endpoint]] {
+	return func(yield func(types.NamespacedName, iter.Seq[*discovery.Endpoint]) bool) {
+		cache.lock.Lock()
+		defer cache.lock.Unlock()
+
+		for serviceName, tracker := range cache.trackerByServiceMap {
+			innerIterator := func(yield func(*discovery.Endpoint) bool) {
+				for _, slice := range tracker.slices {
+					for i := range slice.Endpoints {
+						if !yield(&slice.Endpoints[i]) {
+							return
+						}
+					}
+				}
+			}
+
+			if !yield(serviceName, innerIterator) {
+				return
+			}
+		}
+	}
+}
+
+// isEndpointSliceChanged returns true if the endpointSlice parameter should be set as a new
+// value in the cache.
+func (cache *EndpointSliceCache) isEndpointSliceChanged(serviceKey types.NamespacedName, sliceKey string, endpointSlice *discovery.EndpointSlice) bool {
+	if byServiceData, ok := cache.trackerByServiceMap[serviceKey]; ok {
+		data, ok := byServiceData.slices[sliceKey]
+
+		// If there's already a value, return whether or not this would
+		// change that.
+		if ok {
+			return !reflect.DeepEqual(endpointSlice, data)
+		}
+	}
+
+	// If not in the cache, it should be added.
+	return true
+}
+
+// endpointSliceCacheKeys returns cache keys used for a given EndpointSlice.
+func endpointSliceCacheKeys(endpointSlice *discovery.EndpointSlice) (types.NamespacedName, string, error) {
+	var err error
+	serviceName, ok := endpointSlice.Labels[discovery.LabelServiceName]
+	if !ok || serviceName == "" {
+		err = fmt.Errorf("no %s label set on endpoint slice: %s", discovery.LabelServiceName, endpointSlice.Name)
+	} else if endpointSlice.Namespace == "" || endpointSlice.Name == "" {
+		err = fmt.Errorf("expected EndpointSlice name and namespace to be set: %v", endpointSlice)
+	}
+	return types.NamespacedName{Namespace: endpointSlice.Namespace, Name: serviceName}, endpointSlice.Name, err
+}

--- a/example/basic/example.yaml
+++ b/example/basic/example.yaml
@@ -3,6 +3,9 @@ kind: ClusterRole
 metadata:
   name: shawarma
 rules:
+- apiGroups: ["discovery.k8s.io"]
+  resources: ["endpointslices"]
+  verbs: ["get", "watch", "list"]
 - apiGroups: [""]
   resources: ["endpoints"]
   verbs: ["get", "watch", "list"]

--- a/example/injected/rbac.yaml
+++ b/example/injected/rbac.yaml
@@ -13,6 +13,9 @@ metadata:
   name: shawarma
   namespace: shawarma-example
 rules:
+- apiGroups: ["discovery.k8s.io"]
+  resources: ["endpointslices"]
+  verbs: ["get", "watch", "list"]
 - apiGroups: [""]
   resources: ["endpoints"]
   verbs: ["get", "watch", "list"]

--- a/main.go
+++ b/main.go
@@ -33,10 +33,10 @@ func main() {
 	defer klog.Flush()
 
 	app := cli.Command{
-		Name:    "Shawarma",
-		Usage:   "Sidecar for monitoring a Kubernetes service and notifying the main application when it is live",
+		Name:      "Shawarma",
+		Usage:     "Sidecar for monitoring a Kubernetes service and notifying the main application when it is live",
 		Copyright: "(c) 2019-2025 CenterEdge Software",
-		Version: version,
+		Version:   version,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "log-level",

--- a/notifier.go
+++ b/notifier.go
@@ -35,7 +35,10 @@ func setStateChange(monitorState *monitorState, logger *zap.Logger) {
 		state.Status = inactiveStatus
 	}
 
-	state.ActiveServices = monitorState.endpoints
+	state.ActiveServices = make([]string, 0, len(monitorState.serviceNames))
+	for _, serviceName := range monitorState.serviceNames {
+		state.ActiveServices = append(state.ActiveServices, serviceName.Name)
+	}
 
 	logger.Debug("State changed.",
 		zap.String("status", state.Status),
@@ -63,7 +66,7 @@ func notifyStateChange(url string, logger *zap.Logger) error {
 
 			defer resp.Body.Close()
 
-			logger.Debug("Notification result", 
+			logger.Debug("Notification result",
 				zap.String("status", resp.Status),
 			)
 

--- a/server_test.go
+++ b/server_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -33,7 +33,7 @@ func TestEndpoints(t *testing.T) {
 		// Parse output
 		result := w.Result()
 		defer result.Body.Close()
-		data, err := ioutil.ReadAll(result.Body)
+		data, err := io.ReadAll(result.Body)
 
 		// Err validation
 		if err != nil {


### PR DESCRIPTION
Motivation
----------
As of K8S 1.33, Endpoints are deprecated and EndpointSlices should be used instead.

Modifications
-------------
Monitor EndpointSlices for mutations instead of Endpoints. This requires a more complicated caching mechanism, since there may be multiple EndpointSlices for each service. It also requires some adjustments to the RBAC role.